### PR TITLE
New method extend_guest_validity plus sample

### DIFF
--- a/phpapi/class.unifi.php
+++ b/phpapi/class.unifi.php
@@ -1134,6 +1134,27 @@ class unifiapi
     }
 
     /**
+     * Extend guest validity
+     * --------------
+     * return true on success
+     * required parameter <guest_id> = _id (24 char string) of the guest to extend validity
+     */
+    public function extend_guest_validity($guest_id)
+    {
+        if (!$this->is_loggedin) return false;
+        $return          = false;
+        $json            = json_encode(array('_id' => $guest_id, 'cmd' => 'extend'));
+        $content_decoded = json_decode($this->exec_curl($this->baseurl.'/api/s/'.$this->site.'/cmd/hotspot','json='.$json));
+        if (isset($content_decoded->meta->rc)) {
+            if ($content_decoded->meta->rc == 'ok') {
+                $return = true;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
      * List port forwarding stats
      * --------------------------
      * returns an array of port forwarding stats

--- a/renew.php
+++ b/renew.php
@@ -1,0 +1,36 @@
+<?php
+require_once ("phpapi/class.unifi.php");
+require_once ("config.php");
+
+// must be adapted to your site!
+$site_id = "default";
+$site_name = "*enter your site name*";
+
+$unifidata = new unifiapi ($controlleruser, $controllerpassword, $controllerurl, $site_id, $controllerversion);
+$unifidata->debug = False;
+$loginresults = $unifidata->login();
+
+if ($loginresults === 400) {
+  print "UniFi controller login failure, please check your credentials in config.php.\n";
+}
+else {
+	$guestlist = $unifidata->list_guests();
+	// print "<pre>"; print_r ($guestlist); print "</pre>";
+					// loop thru all known guests
+	foreach ($guestlist as $guest) {
+		// print "<pre>"; print_r ($guest); print "</pre>";
+		print "<pre>" . $guest->_id . " (" . $guest->mac . "), valid until " . date (DATE_ATOM, $guest->end) . " (" . $guest->end . ")</pre>";
+
+					// just a sample: only extend validity of guests which have end date after 2017-04-02
+		if ($guest->end > 1491166482) {
+					// extend clients five times = five days
+			if (!$unifidata->extend_guest_validity ($guest->_id)) print "Extend failed for guest with id " . $guest->_id . "\n";
+			if (!$unifidata->extend_guest_validity ($guest->_id)) print "Extend failed for guest with id " . $guest->_id . "\n";
+			if (!$unifidata->extend_guest_validity ($guest->_id)) print "Extend failed for guest with id " . $guest->_id . "\n";
+			if (!$unifidata->extend_guest_validity ($guest->_id)) print "Extend failed for guest with id " . $guest->_id . "\n";
+			if (!$unifidata->extend_guest_validity ($guest->_id)) print "Extend failed for guest with id " . $guest->_id . "\n";
+		}
+	}
+	
+	$logout_results = $unifidata->logout();
+}


### PR DESCRIPTION
In class.unifi.php I added a new method extend_guest_validity which does the same than the "extend" button in the guest control of the Unifi controller: extending the validity of the guest with the given ID by 1 day.

The renew.php is a really basic sample which:
* browses throuh all guests of a given site
* prints their id and validity
* extends their validity by 5 days calling the above method 5 times