### PR TITLE
fix empty site detection, not populating menu

### DIFF
--- a/index.php
+++ b/index.php
@@ -238,7 +238,7 @@ if (isset($_SESSION['controller'])) {
     /**
      * Get the list of sites managed by the UniFi controller (if not already stored in the $_SESSION array)
      */
-    if (!isset($_SESSION['sites']) || $_SESSION['sites'] === '') {
+    if (!isset($_SESSION['sites']) || empty($_SESSION['sites'])) {
         $sites  = $unifidata->list_sites();
         $_SESSION['sites'] = $sites;
     } else {


### PR DESCRIPTION
I'm wondering if all the === '' should be changed to a more reliable empty detection.  I used "empty()" for this instance.

the === '' was failing and skipping the section where the sites were pulled.

Another thing I noticed was that if the controller url doesn't include the protocol (https://), version detection fails.  Maybe this should be prepended automatically if it's missed?  If I remember correctly, the example in the config template seems to suggest that just the ip and port is fine.  Let me know if I should create an issue or separate pull request for that.


