### PR TITLE
Add session management to the UniFi PHP API

### DIFF
--- a/index.php
+++ b/index.php
@@ -247,6 +247,12 @@ if (isset($_SESSION['controller'])) {
         $sites                       = [];
         $detected_controller_version = 'undetected';
     } else {
+
+        /**
+         * Remember authentication cookie to the controller.
+         */
+        $_SESSION['unificookie'] = $unifidata->getcookie();
+
         /**
          * Get the list of sites managed by the UniFi controller (if not already stored in the $_SESSION array)
          */


### PR DESCRIPTION
For changing your browser tool, just add is this line:
`$_SESSION['unificookie'] = $unifidata->getcookie();`
...  directly when $unifidata->login() was successful

Here some pictures for seesing the difference:
- [x] ![pic1](https://mcmilk.de/tmp/unifi-api/list_devs1.png)
- [x] ![pic1](https://mcmilk.de/tmp/unifi-api/list_devs2.png)
- [x] ![pic1](https://mcmilk.de/tmp/unifi-api/stat_voucher1.png)
- [x] ![pic1](https://mcmilk.de/tmp/unifi-api/stat_voucher2.png)

Thank you for the very nice library. I am writing some small HotSpot system with it... when everything is ready, it will also released @ Github...