### PR TITLE
Fix official API pagination defaults for site dropdown

### DIFF
--- a/ajax/fetch_collection.php
+++ b/ajax/fetch_collection.php
@@ -131,6 +131,7 @@ if (!empty($_SESSION['controller'])) {
          */
         $resource_name = $_POST['selected_collection_resource'] ?? '';
         $fetch_all     = !empty($_POST['fetch_all']);
+        $is_paginated  = !empty($_POST['selected_collection_paginated']);
         $response_mode = $_POST['response_mode'] ?? 'data_only';
 
         if (!empty($method) && !empty($resource_name)) {
@@ -172,7 +173,15 @@ if (!empty($_SESSION['controller'])) {
                     $results['count']     = count($all_data);
                     $results['pagination'] = ['total' => $total, 'fetched_all' => true];
                 } else {
-                    $response = $resource->{$method}();
+                    /**
+                     * Use an explicit default page size for paginated official API endpoints
+                     * instead of relying on the controller's default page size.
+                     */
+                    if ($is_paginated) {
+                        $response = $resource->{$method}(limit: 100);
+                    } else {
+                        $response = $resource->{$method}();
+                    }
                     $json     = $response->json();
 
                     if ($response_mode === 'full') {

--- a/ajax/fetch_sites.php
+++ b/ajax/fetch_sites.php
@@ -77,9 +77,18 @@ if (!empty($_SESSION['controller'])) {
                     $controller['verify_ssl'] ?? true,
                 );
 
-                $response  = $client->sites()->list();
-                $json      = $response->json();
-                $sites_raw = $json['data'] ?? [];
+                $sites_raw = [];
+                $offset    = 0;
+                $limit     = 200;
+
+                do {
+                    $response  = $client->sites()->list(offset: $offset, limit: $limit);
+                    $json      = $response->json();
+                    $page_data = $json['data'] ?? [];
+                    $sites_raw = array_merge($sites_raw, $page_data);
+                    $total     = $json['totalCount'] ?? $json['total'] ?? count($page_data);
+                    $offset   += $limit;
+                } while ($offset < $total && !empty($page_data));
 
                 if (!empty($sites_raw) && is_array($sites_raw)) {
                     foreach ($sites_raw as $site) {

--- a/js/custom.js
+++ b/js/custom.js
@@ -472,6 +472,7 @@ function fetchCollection() {
      */
     if (controller.type === 'official') {
         post_data.selected_collection_resource = selected_collection.resource;
+        post_data.selected_collection_paginated = selected_collection.paginated ? '1' : '0';
         post_data.response_mode = selected_response_mode;
     }
 
@@ -596,6 +597,7 @@ function fetchAllPages() {
         selected_collection_params:   JSON.stringify(selected_collection.params),
         selected_collection_group:    selected_collection.group,
         selected_collection_resource: selected_collection.resource,
+        selected_collection_paginated: selected_collection.paginated ? '1' : '0',
         selected_site_id:             selected_site.id || '',
         selected_output_method:       selected_output_method,
         controller_type:              controller.type,


### PR DESCRIPTION
Hi!

This PR fixes the pagination behavior for the official UniFi API integration that I originally reported in #126.

Official API list endpoints were being called without an explicit limit, so the UniFi API default page size was applied. In practice, this meant:
- paginated collection views only returned the first page by default
- the site dropdown only showed the first page of sites
- users with larger environments were missing sites and collection results unless they explicitly fetched all pages

Fix
This PR updates the official API flow so that:
- paginated collection requests explicitly request 100 results by default
- non-paginated official API endpoints keep their previous behavior
- the site dropdown fetch loops through all site pages using offset/limit and merges the full result set before rendering

Files changed
- ajax/fetch_collection.php
- ajax/fetch_sites.php
- js/custom.js